### PR TITLE
install curl in third-stage for rpi-update

### DIFF
--- a/raspbian/build_raspbian_sd_card.sh
+++ b/raspbian/build_raspbian_sd_card.sh
@@ -206,7 +206,7 @@ rm -f /debconf.set
 
 cd /usr/src/delivery
 apt-get update
-apt-get -y install git-core binutils ca-certificates
+apt-get -y install git-core binutils ca-certificates curl
 wget --continue https://raw.github.com/Hexxeh/rpi-update/master/rpi-update -O /usr/bin/rpi-update
 chmod +x /usr/bin/rpi-update
 mkdir -p /lib/modules/3.1.9+


### PR DESCRIPTION
Thanks for your repo!

I've tried to build a raspbian img, but it seems that rpi-update does not do the kernel update if `curl` is missing. `rpi-update` tries to update itself, but without curl it just exits before doing its work. So I just added curl to the apt-get install command and now the next build looks better:

```
Location: https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update [following]
--2015-01-24 20:09:04--  https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.31.18.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.31.18.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7811 (7.6K) [text/plain]
Saving to: `/usr/bin/rpi-update'

100%[=========================================================================================>] 7,811       --.-K/s   in 0.002s  

2015-01-24 20:09:09 (4.49 MB/s) - `/usr/bin/rpi-update' saved [7811/7811]

/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
 *** Raspberry Pi firmware updater by Hexxeh, enhanced by AndrewS and Dom
 *** Performing self-update
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7811  100  7811    0     0   1479      0  0:00:05  0:00:05 --:--:-- 41547
 *** Relaunching after update
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
 *** Raspberry Pi firmware updater by Hexxeh, enhanced by AndrewS and Dom
 *** We're running for the first time
 *** Backing up files (this will take a few minutes)
 *** Backing up firmware
 *** Backing up modules 3.13.0-43-generic
 *** Downloading specific firmware revision (this will take a few minutes)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   168    0   168    0     0     30      0 --:--:--  0:00:05 --:--:--   400
100 25.7M  100 25.7M    0     0  1876k      0  0:00:14  0:00:14 --:--:-- 3835k
 *** Updating firmware
 *** Updating kernel modules
 *** depmod 3.18.3+
 *** Updating VideoCore libraries
 *** Using HardFP libraries
 *** Updating SDK
 *** Running ldconfig
 *** Storing current firmware revision
 *** Deleting downloaded files
 *** Syncing changes to disk
 *** If no errors appeared, your firmware was successfully updated to 20498c7132ff14e4a5a4da9b3a2ef7b6eb0fd4b3
 *** A reboot is needed to activate the new firmware
Reading package lists... Done
```

It updates to kernel 3.18.3+
